### PR TITLE
Use protocol-relative URL for Google font reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <script type="text/js" src="js/vendor/custom.modernizr.js"></script>
   <script type="text/js" src="js/toWord.js"></script>
 
-  <link href='http://fonts.googleapis.com/css?family=Merriweather+Sans:400,700,800,300' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Merriweather+Sans:400,700,800,300' rel='stylesheet' type='text/css'>
 </head>
 <body>
 	<div class="contain-to-grid sticky">


### PR DESCRIPTION
This avoids potential mixed-content vulnerabilities.
