### PR TITLE
New Material Icons and Updated Links

### DIFF
--- a/css/members.css
+++ b/css/members.css
@@ -48,3 +48,10 @@ a.icon-box {
   padding: 10px;
 }
 
+a {
+  color: #727272;
+}
+
+.settings-panel {
+  height: 55px;
+}

--- a/data/links.json
+++ b/data/links.json
@@ -3,12 +3,6 @@
     "name": "Info",
     "links": [
       {
-        "name": "Wiki",
-        "href": "https://wiki.csh.rit.edu",
-        "icon": "wiki",
-        "popular": true
-      },
-      {
         "name": "Profiles",
         "href": "https://profiles.csh.rit.edu",
         "icon": "profiles",
@@ -47,12 +41,29 @@
         "name": "Alumni Map",
         "href": "https://alumnimap.csh.rit.edu",
         "icon": "world"
+      },
+      {
+        "name": "Discourse",
+        "href": "https://discourse.csh.rit.edu",
+        "icon": "discourse",
+        "popular": true
+      },
+      {
+        "name": "WebNews",
+        "href": "https://webnews.csh.rit.edu",
+        "icon": "webnews",
+        "popular": true
       }
     ]
   },
   {
     "name": "Media",
     "links": [
+      {
+        "name": "Wiki",
+        "href": "https://wiki.csh.rit.edu",
+        "icon": "wiki"
+      },
       {
         "name": "Gallery",
         "href": "https://gallery.csh.rit.edu/main.php",
@@ -83,12 +94,6 @@
         "name": "Soapy",
         "href": "https://soapy.csh.rit.edu",
         "icon": "soapy"
-      },
-      {
-        "name": "WebNews",
-        "href": "https://webnews.csh.rit.edu",
-        "icon": "webnews",
-        "popular": true
       },
       {
         "name": "Webmail",
@@ -138,7 +143,7 @@
       {
         "name": "JIRA",
         "href": "https://jira.csh.rit.edu",
-        "icon": "segfault"
+        "icon": "bug"
       },
       {
         "name": "Slack",
@@ -191,19 +196,14 @@
         "name": "GitHub",
         "href": "https://github.com/ComputerScienceHouse",
         "icon": "github"
-      },
-      {
-        "name": "CoderWall",
-        "href": "https://coderwall.com/team/computer-science-house",
-        "icon": "coderwall"
       }
     ]
   },
   {
-    "name": "Sysadmin",
+    "name": "Systems Admin",
     "links": [
       {
-        "name": "Starrs",
+        "name": "STARRS",
         "href": "https://starrs.csh.rit.edu",
         "icon": "starrs"
       },

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <div class="row">
             <!-- Links -->
             <div class="col-md-9 col-sm-12">
-                <div class="panel panel-primary">
+                <div class="panel panel-primary settings-panel">
                   <div class="panel-body">
                     <strong>Member Resources</strong>
                     <div id="show-icons" class="pull-right">


### PR DESCRIPTION
Added new material icons and updated the styling to match the material standards (54% opacity on active items). 

<img width="1295" alt="screen shot 2016-08-31 at 13 12 38" src="https://cloud.githubusercontent.com/assets/8651166/18138830/a2152e14-6f7c-11e6-85bc-69f0c4e5a64d.png">
