### PR TITLE
Removed redundant (and perma-selected) link

### DIFF
--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -12,7 +12,6 @@
     </div>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right">
-        <li class="active"><a href="#">Members Portal</a></li>
         <li><a href="http://csh.rit.edu">Public Site</a></li>
         <li><a href="https://webauth.csh.rit.edu/logout">Webauth Logout</a></li>
       </ul>


### PR DESCRIPTION
CSH Members is already on the left. This link was always present and always selected.