### PR TITLE
Fixed Facebook Link, Added public page

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -168,8 +168,8 @@
         "name": "Facebook",
         "dropdown": [
           {
-            "name": "Current Members",
-            "href": "https://www.facebook.com/groups/ComputerScienceHouse/"
+            "name": "Public Page",
+            "href": "https://www.facebook.com/RITCSH/"
           },
           {
             "name": "Alumni Group",


### PR DESCRIPTION
https://www.facebook.com/ComputerScienceHouse No longer Exists. Replaced with the public page link