### PR TITLE
Update Code of Conduct link

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -224,7 +224,7 @@
     "links": [
       {
         "name": "CSH Code of Conduct",
-        "href": "https://members.csh.rit.edu/~cshouse/coc.htm"
+        "href": "https://github.com/ComputerScienceHouse/codeofconduct"
       },
       {
         "name": "RIT Service Interruptions",


### PR DESCRIPTION
The GitHub repo is what will be updated if any changes are made to the
CoC so it makes sense for us to point members at that copy.