### PR TITLE
Remove duplicate Discourse link

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -52,11 +52,6 @@
         "href": "https://discourse.csh.rit.edu",
         "icon": "material:forum",
         "popular": true
-      },
-      {
-        "name": "WebNews",
-        "href": "https://webnews.csh.rit.edu",
-        "icon": "material:chat-bubble-outline"
       }
     ]
   },


### PR DESCRIPTION
The discourse link was duplicated as "Webnews". Removed.