### PR TITLE
Change href for Conditional

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -49,7 +49,7 @@
       },
       {
         "name": "Conditional",
-        "href": "https://eval.csh.rit.edu",
+        "href": "https://conditional.csh.rit.edu",
         "icon": "material:group-add"
       },
       {


### PR DESCRIPTION
The link would send you to eval.csh.rit.edu, and always throw a 500 error. This should just send you to the conditional dashboard instead