### PR TITLE
Update Meetings Times for Fall 2019

### DIFF
--- a/data/meetings.json
+++ b/data/meetings.json
@@ -7,56 +7,61 @@
   {
     "name": "PR",
     "day": "MON",
-    "time": "7:00"
+    "time": "6:30"
   },
   {
     "name": "Financial",
     "day": "MON",
-    "time": "8:00"
+    "time": "7:30"
   },
   {
     "name": "Evals",
     "day": "MON",
-    "time": "8:30"
-  },
-  {
-    "name": "Imps",
-    "day": "TUE",
     "time": "7:30"
   },
   {
     "name": "R&D",
-    "day": "TUE",
+    "day": "MON",
     "time": "8:00"
+  },
+  {
+    "name": "GDD Imagine Planning",
+    "day": "MON",
+    "time": "9:00"
+  },
+  {
+    "name": "OpComm",
+    "day": "TUE",
+    "time": "8:30"
   },
   {
     "name": "History",
     "day": "WED",
-    "time": "8:00"
+    "time": "7:00"
   },
   {
     "name": "History Discussion",
     "day": "WED",
-    "time": "8:30"
-  },
-  {
-    "name": "OpComm",
-    "day": "WED",
-    "time": "9:00"
-  },
-  {
-    "name": "Constitution",
-    "day": "THU",
-    "time": "7:00"
+    "time": "7:15"
   },
   {
     "name": "Social",
-    "day": "THU",
+    "day": "WED",
     "time": "8:00"
   },
   {
     "name": "Eboard",
-    "day": "THU",
+    "day": "WED",
     "time": "8:30"
+  },
+  {
+    "name": "CSH Hacks Planning",
+    "day": "THU",
+    "time": "7:00"
+  },
+  {
+    "name": "Imps",
+    "day": "THU",
+    "time": "8:00"
   }
 ]


### PR DESCRIPTION
The meetings still had last spring's times. This updates the times, adds GDD Imagine Planning and CSH Hacks planning, and puts them in chronological order  