### PR TITLE
Revisions to around the web section

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -174,7 +174,7 @@
             "href": "https://www.facebook.com/RITCSH/"
           },
           {
-            "name": "Alumni Group",
+            "name": "Private Group",
             "href": "https://www.facebook.com/groups/16764593277/"
           }
         ],

--- a/data/links.json
+++ b/data/links.json
@@ -187,6 +187,21 @@
         "icon": "brandico:facebook-rect"
       },
       {
+        "name": "Instagram",
+        "dropdown": [
+          {
+            "name": "Primary",
+            "href": "https://www.instagram.com/computersciencehouse/"
+          },
+          {
+            "name": "CSH Hacks",
+            "href": "https://www.instagram.com/cshhacks/"
+          }
+
+        ],
+        "icon": "brandico:instagram-filled"
+      },
+      {
         "name": "Twitter",
         "dropdown": [
           {

--- a/data/links.json
+++ b/data/links.json
@@ -184,6 +184,10 @@
         "name": "Twitter",
         "dropdown": [
           {
+            "name": "Primary Account",
+            "href": "https://twitter.com/RITCSH"
+          },
+          {
             "name": "History",
             "href": "https://twitter.com/CSH_History"
           },
@@ -192,9 +196,10 @@
             "href": "https://twitter.com/OPCOMM"
           },
           {
-            "name": "The Committee",
-            "href": "https://twitter.com/FUMNCommittee"
+            "name": "CSH Hacks",
+            "href": "https://twitter.com/csh_hacks"
           }
+
         ],
         "icon": "brandico:twitter-bird"
       },

--- a/data/links.json
+++ b/data/links.json
@@ -176,7 +176,13 @@
           {
             "name": "Private Group",
             "href": "https://www.facebook.com/groups/16764593277/"
+          },
+          {
+            "name": "CSH Hacks Page",
+            "href": "https://www.facebook.com/cshhacks"
           }
+
+          
         ],
         "icon": "brandico:facebook-rect"
       },


### PR DESCRIPTION
Revisions to around the web section

- added a section for instagram that links to the main CSH instagram account and the CSH Hacks instagram account 
- removed link to 'the committee' twitter account
- added link to CSH twitter & CSH Hacks twitter
- added a link to the CSH Hacks facebook page