### PR TITLE
added correct link to private csh LinkedIn group

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -200,7 +200,7 @@
       },
       {
         "name": "LinkedIn",
-        "href": "https://www.linkedin.com/groups?gid=971",
+        "href": "https://www.linkedin.com/groups/971/",
         "icon": "brandico:linkedin"
       },
       {


### PR DESCRIPTION
previous link was broken and did not point to the CSH LinkedIn group