### PR TITLE
Add link to eac.csh.rit.edu

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -167,7 +167,7 @@
         "icon": "material:folder-special"
       },
       {
-        "name": "External Accounts",
+        "name": "External Accounts Connector",
         "href": "https://eac.csh.rit.edu",
         "icon": "material:extension"
       }

--- a/data/links.json
+++ b/data/links.json
@@ -165,6 +165,11 @@
         "name": "Bucket",
         "href": "https://bucket.csh.rit.edu",
         "icon": "material:folder-special"
+      },
+      {
+        "name": "External Accounts",
+        "href": "https://eac.csh.rit.edu",
+        "icon": "material:extension"
       }
     ]
   },


### PR DESCRIPTION
I am like, 0 for 20 on remembering this stupid URL. This should be on Members.