### PR TITLE
Change 'Systems Admin' to 'OpComm'

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -216,7 +216,7 @@
     ]
   },
   {
-    "name": "Systems Admin",
+    "name": "OpComm",
     "links": [
       {
         "name": "Password Reset",


### PR DESCRIPTION
I think it fits better and the phrase 'Systems Admin' makes my skin crawl.