### PR TITLE
Changed EBoard meeting time to 9pm

### DIFF
--- a/data/meetings.json
+++ b/data/meetings.json
@@ -17,7 +17,7 @@
   {
     "name": "Eboard",
     "day": "MON",
-    "time": "8:30"
+    "time": "9:00"
   },
   {
     "name": "PR",


### PR DESCRIPTION
Updated sidebar to show the updated eboard meeting time (9pm instead of 8:30pm)