### PR TITLE
removed broken FMS floor plan link

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -290,10 +290,6 @@
       {
         "name": "RIT Service Interruptions",
         "href": "https://www.rit.edu/fa/facilities/content/service-interruptions"
-      },
-      {
-        "name": "CSH Floor Plan",
-        "href": "https://facilities.rit.edu/campus/floorplans/buildings/043/3.pdf"
       }
     ]
   }

--- a/data/links.json
+++ b/data/links.json
@@ -293,7 +293,7 @@
       },
       {
         "name": "CSH Floor Plan",
-        "href": "https://www.rit.edu/~w-d9/drupal-9.4.1/sites/rit.edu.facilitiesmanagement/files/restricted/043-3.pdf"
+        "href": "https://www.rit.edu/facilitiesmanagement/sites/rit.edu.facilitiesmanagement/files/restricted/043-3.pdf"
       }
     ]
   }

--- a/data/links.json
+++ b/data/links.json
@@ -290,6 +290,10 @@
       {
         "name": "RIT Service Interruptions",
         "href": "https://www.rit.edu/fa/facilities/content/service-interruptions"
+      },
+      {
+        "name": "CSH Floor Plan",
+        "href": "https://www.rit.edu/~w-d9/drupal-9.4.1/sites/rit.edu.facilitiesmanagement/files/restricted/043-3.pdf"
       }
     ]
   }


### PR DESCRIPTION
[This link](https://www.rit.edu/facilitiesmanagement/campus/floorplans/buildings/043/3.pdf) is no longer valid, so I removed it entirely.