### PR TITLE
Add a stuff link

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -152,6 +152,11 @@
         "icon": "material:content-paste"
       },
       {
+        "name": "Stuff",
+        "href": "https://stuff.csh.rit.edu",
+        "icon": "material:view-list"
+      },
+      {
         "name": "Theme Switcher",
         "href": "https://themeswitcher.csh.rit.edu",
         "icon": "material:filter"


### PR DESCRIPTION
This PR adds a link to https://stuff.csh.rit.edu