### PR TITLE
Remove ballots from members portal

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -152,11 +152,6 @@
         "popular": true
       },
       {
-        "name": "Ballots",
-        "href": "https://ballots.csh.rit.edu",
-        "icon": "material:content-paste"
-      },
-      {
         "name": "Theme Switcher",
         "href": "https://themeswitcher.csh.rit.edu",
         "icon": "material:filter"


### PR DESCRIPTION
Removed dead link for ballots.csh.rit.edu from members portal