### PR TITLE
Add Plex Catalog to media section + remove broken service from services section

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -93,6 +93,11 @@
         "name": "Game Night",
         "href": "https://game-night.csh.rit.edu",
         "icon": "foundation:die-three"
+      },
+      {
+        "name": "Plex Catalog",
+        "href": "https://plex.csh.rit.edu",
+        "icon": "material:movie"
       }
     ]
   },

--- a/data/links.json
+++ b/data/links.json
@@ -190,11 +190,6 @@
       	"name": "Pings",
       	"href": "https://pings.csh.rit.edu",
       	"icon": "material:add-alert"
-      },
-      {
-        "name": "CatJam",
-        "href": "https://catjam.csh.rit.edu",
-        "icon": "webhostinghub:cat"
       }
     ]
   },


### PR DESCRIPTION
## What

Adds a link to Plex Catalog to the media section, and removes CatJam from the services section since the service currently does not work.

## Why

I wanted to add a new house service to the members portal and remove the one that I know is broken right now

## Test Plan

I ran the website and saw the cat was gone and the plex catalog link was there

## Env Vars

No

## Checklist

- [x] Tested all changes locally
